### PR TITLE
Use MacroFab's pcb-stackup-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "gerber-to-svg": "^2.1.0",
-    "pcb-stackup-core": "^3.0.0",
+    "pcb-stackup-core": "git://github.com/MacroFab/pcb-stackup-core.git",
     "shortid": "^2.2.6",
     "whats-that-gerber": "^2.1.0"
   }


### PR DESCRIPTION
If we use the upstream "official" version, we don't get multiple files per layer or filled in holes and cutouts.