### PR TITLE
Lets live dangerously: updated gerber-to-svg to v4.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "gerber-to-svg": "^4.2.8",
-    "pcb-stackup-core": "https://github.com/metacollin/pcb-stackup-core.git",
+    "pcb-stackup-core": "https://github.com/MacroFab/pcb-stackup-core.git",
     "shortid": "^2.2.6",
     "whats-that-gerber": "^2.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "gerber-to-svg": "^4.2.8",
-    "pcb-stackup-core": "https://github.com/MacroFab/pcb-stackup-core.git",
+    "pcb-stackup-core": "https://github.com/metacollin/pcb-stackup-core.git",
     "shortid": "^2.2.6",
     "whats-that-gerber": "^2.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "zuul-ngrok": "^4.0.0"
   },
   "dependencies": {
-    "gerber-to-svg": "^2.1.0",
+    "gerber-to-svg": "^4.2.8",
     "pcb-stackup-core": "https://github.com/MacroFab/pcb-stackup-core.git",
     "shortid": "^2.2.6",
     "whats-that-gerber": "^2.1.0"


### PR DESCRIPTION
It doesn't break anything on my dev instance.
Related: https://github.com/MacroFab/pcb-stackup-core/pull/2